### PR TITLE
Use explicit syntax for sidebars

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1,35 +1,37 @@
 module.exports = {
-  someSidebar: {
-    Introduction: [
-      'intro',
-      'docsguide'
-    ],
-    Architecture: [
-      "architecture/overview",
-      "architecture/connections",
-      "architecture/matching",
-    ],
-    Installation: [
-      "installation/introduction",
-      "installation/itp",
-      "installation/mmo",
-      "installation/sp",
-      "installation/mojaloop",
-    ],
-    "Use Cases": [
-      "usecases", 
-      "uclist", 
-      "uccreation"
-    ],
-    "Test Cases": [
-      "tclist", 
-      "tctemplate"
-    ],
-    "User Manual": [
-      "quickguide", 
-      "session", 
-      "tests", 
-      "results"
-    ],
-  },
+  docs: [
+    "intro",
+    "docsguide",
+    {
+      type: "category",
+      label: "Architecture",
+      items: [
+        "architecture/overview",
+        "architecture/connections",
+        "architecture/matching",
+      ],
+    },
+    {
+      type: "category",
+      label: "Installation",
+      items: [
+        "installation/introduction",
+        "installation/itp",
+        "installation/mmo",
+        "installation/sp",
+        "installation/mojaloop",
+      ],
+    },
+    {
+      type: "category",
+      label: "Use Cases",
+      items: ["usecases", "uclist", "uccreation"],
+    },
+    { type: "category", label: "Test Cases", items: ["tclist", "tctemplate"] },
+    {
+      type: "category",
+      label: "User Manual",
+      items: ["quickguide", "session", "tests", "results"],
+    },
+  ],
 };


### PR DESCRIPTION
This syntax allows separate top-level links. In my opinion is also better because the order of object keys is technically unspecified in ECMAScript, so putting the items in an array is the only way to guarantee the order (currently the docusaurus default relies on the implementation detail that all browsers currently iterate through object keys in insertion order).
![image](https://user-images.githubusercontent.com/1517675/85268315-41b4ed80-b46e-11ea-9688-1b495d73e1fb.png)
